### PR TITLE
feat(resource): import clusters and ips using names and address

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -3,12 +3,12 @@
 page_title: "metal_cluster Resource - terraform-provider-metal"
 subcategory: ""
 description: |-
-  Managing Clusters of worker nodes. Required permissions: Cluster *.
+  Managing Clusters of worker nodes. Required permissions: Cluster *. Can be imported by ID or name.
 ---
 
 # metal_cluster (Resource)
 
-Managing Clusters of worker nodes. Required permissions: `Cluster *`.
+Managing Clusters of worker nodes. Required permissions: `Cluster *`. Can be imported by ID or name.
 
 ## Example Usage
 

--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -7,7 +7,7 @@ description: |-
   Services get an IP automatically on creation.
   Services and gateway IPs are dynamic by default.
   You can use an IP address in several clusters and locations at the same time.
-  Required permissions: IP *.
+  Required permissions: IP *. Can be imported by ID, name or ip address.
 ---
 
 # metal_public_ip (Resource)
@@ -16,7 +16,7 @@ Each cluster gets an IP automatically provided on the internet gateway for outgo
 Services get an IP automatically on creation. 
 Services and gateway IPs are dynamic by default. 
 You can use an IP address in several clusters and locations at the same time. 
-Required permissions: `IP *`.
+Required permissions: `IP *`. Can be imported by ID, name or ip address.
 
 ## Example Usage
 

--- a/internal/cluster/data_source.go
+++ b/internal/cluster/data_source.go
@@ -118,5 +118,5 @@ func findUuidByName(list []*apiv1.Cluster, name string) (string, error) {
 			return e.Uuid, nil
 		}
 	}
-	return "", fmt.Errorf("cluster name not found in list")
+	return "", fmt.Errorf("cluster name not found")
 }

--- a/internal/cluster/helpers.go
+++ b/internal/cluster/helpers.go
@@ -187,7 +187,7 @@ func clusterResponseMapping(clusterP *apiv1.Cluster) clusterModel {
 	}
 }
 
-func clusterOperationWaitStatus(ctx context.Context, clusterP *Cluster, statusRequest *apiv1.ClusterServiceWatchStatusRequest, operationWhitelist []string) error {
+func clusterOperationWaitStatus(ctx context.Context, clusterP *ClusterResource, statusRequest *apiv1.ClusterServiceWatchStatusRequest, operationWhitelist []string) error {
 	// add timeout to context
 	watchCtx, watchCancel := context.WithTimeout(ctx, 20*time.Minute)
 	defer watchCancel()

--- a/internal/cluster/helpers.go
+++ b/internal/cluster/helpers.go
@@ -116,14 +116,20 @@ func clusterUpdateRequestMapping(state *clusterModel, plan *clusterModel, respon
 	// map terraform workers list arguments to WorkerUpdate struct
 	var workersSlice []*apiv1.WorkerUpdate
 	for _, v := range plan.Workers {
-		workersSlice = append(workersSlice, &apiv1.WorkerUpdate{
-			Name:           v.Name.ValueString(),
-			MachineType:    pointer.Pointer(v.MachineType.ValueString()),
-			Minsize:        pointer.Pointer(uint32(v.Minsize.ValueInt64())),
-			Maxsize:        pointer.Pointer(uint32(v.Maxsize.ValueInt64())),
-			Maxsurge:       pointer.Pointer(uint32(v.Maxsurge.ValueInt64())),
-			Maxunavailable: pointer.Pointer(uint32(v.Maxunavailable.ValueInt64())),
-		})
+		workerUpdate := &apiv1.WorkerUpdate{
+			Name:        v.Name.ValueString(),
+			MachineType: pointer.Pointer(v.MachineType.ValueString()),
+			Minsize:     pointer.Pointer(uint32(v.Minsize.ValueInt64())),
+			Maxsize:     pointer.Pointer(uint32(v.Maxsize.ValueInt64())),
+		}
+		if !v.Maxsurge.IsNull() {
+			workerUpdate.Maxsurge = pointer.Pointer(uint32(v.Maxsurge.ValueInt64()))
+		}
+		if !v.Maxunavailable.IsNull() {
+			workerUpdate.Maxunavailable = pointer.Pointer(uint32(v.Maxunavailable.ValueInt64()))
+		}
+		workersSlice = append(workersSlice, workerUpdate)
+
 	}
 
 	// check workersSlice slice length

--- a/internal/cluster/resource.go
+++ b/internal/cluster/resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/hashicorp/go-uuid"
 	path "github.com/hashicorp/terraform-plugin-framework/path"
 	resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -14,34 +15,34 @@ import (
 )
 
 var (
-	_ resource.Resource                = &Cluster{}
-	_ resource.ResourceWithConfigure   = &Cluster{}
-	_ resource.ResourceWithImportState = &Cluster{}
+	_ resource.Resource                = &ClusterResource{}
+	_ resource.ResourceWithConfigure   = &ClusterResource{}
+	_ resource.ResourceWithImportState = &ClusterResource{}
 )
 
 func NewClusterResource() resource.Resource {
-	return &Cluster{}
+	return &ClusterResource{}
 }
 
-type Cluster struct {
+type ClusterResource struct {
 	session *session.Session
 }
 
 // Metadata implements resource.Resource.
-func (*Cluster) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+func (*ClusterResource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
 	response.TypeName = request.ProviderTypeName + "_cluster"
 }
 
 // Schema implements resource.Resource.
-func (*Cluster) Schema(ctx context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
+func (*ClusterResource) Schema(ctx context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes:          clusterResourceAttributes(),
-		MarkdownDescription: "Managing Clusters of worker nodes. Required permissions: `Cluster *`.",
+		MarkdownDescription: "Managing Clusters of worker nodes. Required permissions: `Cluster *`. Can be imported by ID or name.",
 	}
 }
 
 // Configure implements resource.ResourceWithConfigure.
-func (clusterP *Cluster) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+func (clusterP *ClusterResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
 	if request.ProviderData == nil {
 		return
 	}
@@ -59,7 +60,7 @@ func (clusterP *Cluster) Configure(ctx context.Context, request resource.Configu
 }
 
 // Create implements resource.Resource.
-func (clusterP *Cluster) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+func (clusterP *ClusterResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	// Read Terraform plan data into the model
 	var plan clusterModel
 	diagPlan := request.Plan.Get(ctx, &plan)
@@ -100,7 +101,7 @@ func (clusterP *Cluster) Create(ctx context.Context, request resource.CreateRequ
 }
 
 // Read implements resource.Resource.
-func (clusterP *Cluster) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+func (clusterP *ClusterResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
 	// Read Terraform prior state data into the model
 	var state clusterModel
 	diagState := request.State.Get(ctx, &state)
@@ -132,7 +133,7 @@ func (clusterP *Cluster) Read(ctx context.Context, request resource.ReadRequest,
 }
 
 // Update implements resource.Resource.
-func (clusterP *Cluster) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+func (clusterP *ClusterResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	// Read Terraform prior state data into the model
 	var state clusterModel
 	diags := request.State.Get(ctx, &state)
@@ -176,7 +177,7 @@ func (clusterP *Cluster) Update(ctx context.Context, request resource.UpdateRequ
 }
 
 // Delete implements resource.Resource.
-func (clusterP *Cluster) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+func (clusterP *ClusterResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
 	var state clusterModel
 	diags := request.State.Get(ctx, &state)
 	response.Diagnostics.Append(diags...)
@@ -206,6 +207,28 @@ func (clusterP *Cluster) Delete(ctx context.Context, request resource.DeleteRequ
 }
 
 // ImportState implements resource.ResourceWithImportState.
-func (*Cluster) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+func (r *ClusterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if _, err := uuid.ParseUUID(req.ID); err == nil {
+		resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+		return
+	}
+
+	name := req.ID
+	listRequestMessage := &apiv1.ClusterServiceListRequest{
+		Project: r.session.Project,
+	}
+	clusterList, err := r.session.Client.Apiv1().Cluster().List(ctx, connect.NewRequest(listRequestMessage))
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to get cluster list", err.Error())
+		return
+	}
+	// find uuid and set uuidString
+	list := clusterList.Msg.Clusters
+	uuidStr, err := findUuidByName(list, name)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to find cluster with name %v", req.ID), err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), uuidStr)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
 }

--- a/internal/cluster/schema.go
+++ b/internal/cluster/schema.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -98,11 +99,17 @@ func clusterResourceAttributes() map[string]resourceschema.Attribute {
 						Computed:            true,
 						Optional:            true,
 						MarkdownDescription: "The maximum count of available nodes which can be updated at once",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"max_unavailable": resourceschema.Int64Attribute{
 						Computed:            true,
 						Optional:            true,
 						MarkdownDescription: "The maximum count of nodes which can be unavailable during node updates",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -198,7 +198,7 @@ func assumeDefaultsFromApiToken(apiToken string) error {
 		return err
 	}
 
-	viper.SetDefault("api-url", claims.Issuer)
+	viper.Set("api-url", claims.Issuer)
 
 	var projects []string
 


### PR DESCRIPTION
This allows importing clusters easily. Here I use an import block, which tries to import the resource if it already exists on the server, but not in the terraform state. 

```terraform
import {
  to = metal_cluster.my-cluster
  id = "my-cluster"
}

resource "metal_cluster" "my-cluster" {
  name       = "my-cluster"
  kubernetes = "1.27.8"
  partition  = "eqx-mu4"
  workers = [
    {
      name         = "default"
      machine_type = "n1-medium-x86"
      min_size     = 1
      max_size     = 3
    }
  ]
}

```