### PR TITLE
fix(kubeconfig): externals

### DIFF
--- a/internal/kubeconfig/data_source.go
+++ b/internal/kubeconfig/data_source.go
@@ -126,6 +126,9 @@ func parseKubeconfig(kubeconf string, diag diag.Diagnostics) *kubeconfigContent 
 		}
 		external.ClusterCaCertificate = types.StringValue(string(ca))
 	}
+	if external.Host.IsNull() || external.Host.IsUnknown() {
+		diag.AddAttributeWarning(path.Root("external").AtName("host"), "not found", "could not be extracted")
+	}
 
 	for _, u := range kubeconfig.Users {
 		if !strings.HasSuffix(u.Name, "external") {
@@ -144,7 +147,6 @@ func parseKubeconfig(kubeconf string, diag diag.Diagnostics) *kubeconfigContent 
 		external.ClientCertificate = types.StringValue(string(clientCert))
 	}
 	return external
-
 }
 
 type rawKubeconfig struct {

--- a/internal/kubeconfig/data_source.go
+++ b/internal/kubeconfig/data_source.go
@@ -10,6 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -98,46 +99,52 @@ func (d *KubeconfigDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	}
 	tflog.Trace(ctx, "generated kubeconfig")
 
-	data.Raw = types.StringValue(kcResp.Msg.GetKubeconfig())
+	rawString := kcResp.Msg.GetKubeconfig()
+	data.Raw = types.StringValue(rawString)
 
+	data.External = parseKubeconfig(rawString, resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func parseKubeconfig(kubeconf string, diag diag.Diagnostics) *kubeconfigContent {
 	var kubeconfig rawKubeconfig
-	err = yaml.Unmarshal([]byte(kcResp.Msg.GetKubeconfig()), &kubeconfig)
+	err := yaml.Unmarshal([]byte(kubeconf), &kubeconfig)
 	if err != nil {
-		resp.Diagnostics.AddAttributeWarning(path.Root("external"), "parsing raw kubeconfig failed", err.Error())
+		diag.AddAttributeWarning(path.Root("external"), "parsing raw kubeconfig failed", err.Error())
 	}
-	data.External = &kubeconfigContent{}
+	external := &kubeconfigContent{}
 
 	for _, c := range kubeconfig.Clusters {
-		if !strings.HasSuffix("external", c.Name) {
+		if !strings.HasSuffix(c.Name, "external") {
 			continue
 		}
-		data.External.Host = types.StringValue(c.Cluster.Server)
+		external.Host = types.StringValue(c.Cluster.Server)
 
 		ca, err := base64.StdEncoding.DecodeString(c.Cluster.CertificateAuthorityData)
 		if err != nil {
-			resp.Diagnostics.AddAttributeWarning(path.Root("external").AtName("cluster_ca_certificate"), "decoding failed", err.Error())
+			diag.AddAttributeWarning(path.Root("external").AtName("cluster_ca_certificate"), "decoding failed", err.Error())
 		}
-		data.External.ClusterCaCertificate = types.StringValue(string(ca))
+		external.ClusterCaCertificate = types.StringValue(string(ca))
 	}
 
 	for _, u := range kubeconfig.Users {
-		if !strings.HasSuffix("external", u.Name) {
+		if !strings.HasSuffix(u.Name, "external") {
 			continue
 		}
 		clientKey, err := base64.StdEncoding.DecodeString(u.User.ClientKeyData)
 		if err != nil {
-			resp.Diagnostics.AddAttributeWarning(path.Root("external").AtName("client_key"), "decoding failed", err.Error())
+			diag.AddAttributeWarning(path.Root("external").AtName("client_key"), "decoding failed", err.Error())
 		}
-		data.External.ClientKey = types.StringValue(string(clientKey))
+		external.ClientKey = types.StringValue(string(clientKey))
 
 		clientCert, err := base64.StdEncoding.DecodeString(u.User.ClientCertificateData)
 		if err != nil {
-			resp.Diagnostics.AddAttributeWarning(path.Root("external").AtName("client_certificate"), "decoding failed", err.Error())
+			diag.AddAttributeWarning(path.Root("external").AtName("client_certificate"), "decoding failed", err.Error())
 		}
-		data.External.ClientCertificate = types.StringValue(string(clientCert))
+		external.ClientCertificate = types.StringValue(string(clientCert))
 	}
+	return external
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 type rawKubeconfig struct {

--- a/internal/kubeconfig/kubeconfig_acc_test.go
+++ b/internal/kubeconfig/kubeconfig_acc_test.go
@@ -22,52 +22,40 @@ func TestAccKubeconfigDataSource(t *testing.T) {
 			{
 				Config: testAccExampleClusterSeed,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("metal_cluster.panda", "name", "tf-kubeconf"),
+					resource.TestCheckResourceAttr("data.metal_cluster.panda", "name", "tfix-panda"),
 				),
 			},
 			{
 				Config: testAccExampleClusterSeed + testAccExampleDataSource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "raw"),
-					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "external"),
-					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "host"),
-					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "client_certificate"),
-					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "client_key"),
-					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "cluster_ca_certificate"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "external.host"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "external.client_certificate"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "external.client_key"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "external.cluster_ca_certificate"),
 				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:  testAccExampleClusterSeed,
+				Destroy: true,
 			},
 		},
 	})
 }
 
 const testAccExampleClusterSeed = `
-resource "metal_cluster" "panda" {
-	name = "tf-kubeconf"
-	kubernetes = "1.27.9"
-	workers = [
-		{
-			name = "group-0"
-			machine_type = "c1-medium-x86"
-			max_size = 2
-			min_size = 1
-		}
-	]
-	// FIXME: https://github.com/metal-stack-cloud/terraform-provider-metal/issues/51
-	// maintenance = {
-	// 	time_window = {
-	// 		begin = "05:00 AM"
-	// 		duration = 2
-	// 	}
-	// }
+data "metal_cluster" "panda" {
+	name = "tfix-panda"
 }
 `
 
 const testAccExampleDataSource = `
 data "metal_kubeconfig" "panda_kubeconfig" {
-	id = resource.metal_cluster.panda.id
+	id = data.metal_cluster.panda.id
 	expiration = "1h02m"
 }
-output "panda_kubeconfig" {
-  value = data.metal_kubeconfig.panda_kubeconfig
+output "panda_kubeconfig_external" {
+  value = data.metal_kubeconfig.panda_kubeconfig.external
 }
 `

--- a/internal/kubeconfig/kubeconfig_acc_test.go
+++ b/internal/kubeconfig/kubeconfig_acc_test.go
@@ -1,0 +1,73 @@
+package kubeconfig_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/metal-stack-cloud/terraform-provider-metal/internal/provider"
+)
+
+var (
+	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+		"metal": providerserver.NewProtocol6WithError(provider.New("test")()),
+	}
+)
+
+func TestAccKubeconfigDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExampleClusterSeed,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("metal_cluster.panda", "name", "tf-kubeconf"),
+				),
+			},
+			{
+				Config: testAccExampleClusterSeed + testAccExampleDataSource,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "raw"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig", "external"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "host"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "client_certificate"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "client_key"),
+					resource.TestCheckResourceAttrSet("data.metal_kubeconfig.panda_kubeconfig.external", "cluster_ca_certificate"),
+				),
+			},
+		},
+	})
+}
+
+const testAccExampleClusterSeed = `
+resource "metal_cluster" "panda" {
+	name = "tf-kubeconf"
+	kubernetes = "1.27.9"
+	workers = [
+		{
+			name = "group-0"
+			machine_type = "c1-medium-x86"
+			max_size = 2
+			min_size = 1
+		}
+	]
+	// FIXME: https://github.com/metal-stack-cloud/terraform-provider-metal/issues/51
+	// maintenance = {
+	// 	time_window = {
+	// 		begin = "05:00 AM"
+	// 		duration = 2
+	// 	}
+	// }
+}
+`
+
+const testAccExampleDataSource = `
+data "metal_kubeconfig" "panda_kubeconfig" {
+	id = resource.metal_cluster.panda.id
+	expiration = "1h02m"
+}
+output "panda_kubeconfig" {
+  value = data.metal_kubeconfig.panda_kubeconfig
+}
+`

--- a/internal/kubeconfig/parsing_test.go
+++ b/internal/kubeconfig/parsing_test.go
@@ -1,0 +1,56 @@
+package kubeconfig
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestKubeconfigExtraction(t *testing.T) {
+	kubeconfig := `
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1akNDQWM2Z0F3SUJBZ0lRYWtuNjNlWThreitkZrcHdaazVIR3RPaWErRXdEUVlKS29aSWh2Y04KQVFFTEJRQURnZ0VCQUlmblROZzNubU4yakFKWUkvYnVqWDhwMk11TWpZOStYVThwSjNIbi9xVjZId05MbXdXSwpIYk5NMDJ6WmxXeFBJZ2dDV3BFQW84VVFKU044RVBVQk1mNDZJYnpVbG9LN3JXMGFwK3crb0prUWZ6cTNZb3JtCjZEaDFyQzZMamg1Q3ZBZ0VtYzMyOUhlVFNDaUtVeTZ3V01kYy9oREQwNEtsQlhHaXpsY2RqYVN6ME1Ud2R2VSsKMURkWk1Lbmg1OVVCVi9TR2VqRGJsdWNhaU84RkZGbFp0SHYrQ1RlYVoxYzdqWFo2cTdVTFI0L2k3SzM0WE5qOQpxOXhsR3N1N045dWdoWGFoYUF4NlNVZ3B3bUZybmVaWkxZcDdLTDFybzZmKzNqZGo1K3JWV0dueVE2ZkR3ME1iCjRXcHFjYTcvcGFnT0Q4cVM4S1ZiWUJPek9ka1Z5N0ozMXFzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://api.cluster.f8e67080ba.k8s.metalstackcloud.io
+  name: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1akNDQWM2Z0F3SUJBZ0lRYWtuNjNlWThreitaRE1MZ09kd2sY2RqYVN6ME1Ud2R2VSsKMURkWk1Lbmg1OVVCVi9TR2VqRGJsdWNhaU84RkZGbFp0SHYrQ1RlYVoxYzdqWFo2cTdVTFI0L2k3SzM0WE5qOQpxOXhsR3N1N045dWdoWGFoYUF4NlNVZ3B3bUZybmVaWkxZcDdLTDFybzZmKzNqZGo1K3JWV0dueVE2ZkR3ME1iCjRXcHFjYTcvcGFnT0Q4cVM4S1ZiWUJPek9ka1Z5N0ozMXFzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://api.cluster.f8e67080ba.internal.k8s.metalstackcloud.io
+  name: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-internal
+contexts:
+- context:
+    cluster: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+    user: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+  name: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+- context:
+    cluster: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-internal
+    user: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+  name: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-internal
+current-context: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+kind: Config
+preferences: {}
+users:
+- name: garden-f8e67080-ba68-41d2-ad44-59dc65a09a33--cluster-external
+  user:
+    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKekNDQWcrZ0F3SUJBZ0lFkWUl5YjFjbk16Tmx6OXBLa3lmM1V2OXNoTDAwQlJhVTRCVXNVVFdNekRKUTQ5dnRpYVg0cldlbCt2UwpLV3dqbGdLZEJiL25zczJlNmhrcG9qL3BvNXp0bmY4ditJSS9iY1MxM2Q5N3VOY2E3MFVyY2ZSTHFOQVY3VVc1Ckc0b2plUzk5YlkvRG1ZSm1LZldVWFN3am0rVXZ4bnBpRXpTY3FLeWNzRFBOVEFkdmZaNnExSGJiTCtkWEhOelQKMWpxZ2FHUGxIdGRWck5GajF3UmFQV0FFS3Ntai9oLzd6QmtlK0tzWUcvbTRnOXozOHFLVHd3Y0x2QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBeml1SitIN2lZRFJieUZicWhnK2twMnpPQW11OVlLZ29HRzdTbkFDClRzUTNTYlFRNmlDU3gxbHgvT05WN08wQ2dZQXVMTkMwZmtnUjBaL0dRS3FiVDE5elZaWHJpNUhPMmZCNkJWankKMmtLSHNjZUFMQ05zNzhnK1I1dkt1TVFFMGRuQ05rTzlUdW1IMDVyeWhFTm5VYW9IR0ZFSUY5eWYxUWFQSFg2Sgo0YStwUnNwbWpVRlhiWXY3ZEdYUGRKSFpVV2xsb3ppckZaQ1BZS0pudm1sTXN6WEZmblcwWTJ3WjRGKy8yVFV1CmVnVVhXUUtCZ1FDYXBhUEk2WlEraEdsd21FaGU1L3FVNnZaNUVxdUFHN2tLU2gyZ1FjQkpzb0FvYTdHQXpZQlIKMVlhSmtrdytHRTNkZVU2Z0tFZTBXWVhGd2Z5VVhUQlVGUzI1WUp5NnYzOGhsSk0yb3JvR2hzaWpjZi9OUEVocApnYmQrbEg0bHRGMUtFOVpYMFQ2Q0pFTXpkaktNV3llMGU4TWMveldIdVNNblliTktJR0J1TWc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+`
+	diags := diag.Diagnostics{}
+	external := parseKubeconfig(kubeconfig, diags)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics, got %s", diags)
+	}
+	if external.Host.IsNull() || external.Host.IsUnknown() {
+		t.Errorf("host could not be parsed")
+	}
+	if external.ClientKey.IsNull() || external.ClientKey.IsUnknown() {
+		t.Errorf("client key could not be parsed")
+	}
+	if external.ClientCertificate.IsNull() || external.ClientCertificate.IsUnknown() {
+		t.Errorf("client certificate could not be parsed")
+	}
+	if external.ClusterCaCertificate.IsNull() || external.ClusterCaCertificate.IsUnknown() {
+		t.Errorf("cluster ca certificate could not be parsed")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -110,6 +110,8 @@ func (p *MetalstackCloudProvider) Configure(ctx context.Context, req provider.Co
 	}
 
 	apiToken := os.Getenv("METAL_STACK_CLOUD_API_TOKEN")
+	apiUrl = os.Getenv("METAL_STACK_CLOUD_API_URL")
+	project = os.Getenv("METAL_STACK_CLOUD_PROJECT")
 	if !data.ApiToken.IsNull() {
 		apiToken = data.ApiToken.ValueString()
 	}
@@ -121,8 +123,6 @@ func (p *MetalstackCloudProvider) Configure(ctx context.Context, req provider.Co
 			err.Error(),
 		)
 	}
-	apiUrl = os.Getenv("METAL_STACK_CLOUD_API_URL")
-	project = os.Getenv("METAL_STACK_CLOUD_PROJECT")
 	if !data.Project.IsNull() {
 		project = data.Project.ValueString()
 	}


### PR DESCRIPTION
The externals of a kubeconfig were not parsed correctly. Added an accteptance test and a regular one to make sure it works.

Also fixes a regression that occurred when trying to infer projects (viper fixed it for us while we had it)

Previously `metal_kubeconfig.thename.external.host` and the other fields were emtpy.