### PR TITLE
feat(ip): allow chaning ip types eventually losing the address

### DIFF
--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -39,6 +39,9 @@ resource "metal_public_ip" "my_ip" {
 ### Optional
 
 - `description` (String) Here you can give your IP an optional description for your own use.
+- `type` (String) Determines the type of the public ip address. 
+	If you want the IP to outlive the cluster lifecycle, mark it as static. Otherwise it will be deleted along with the cluster. 
+	Another use case would be if you want to have a stable egress address on the internet gateway for your cluster.
 
 ### Read-Only
 
@@ -48,7 +51,4 @@ resource "metal_public_ip" "my_ip" {
 - `network` (String) The network this address is bound to.
 - `project` (String) The project this address is part of. Cannot be moved.
 - `tags` (List of String) The tags used to organize this address.
-- `type` (String) Determines the type of the public ip address. 
-	If you want the IP to outlive the cluster lifecycle, mark it as static. Otherwise it will be deleted along with the cluster. 
-	Another use case would be if you want to have a stable egress address on the internet gateway for your cluster.
 - `updated_at` (String) Indicates when this IP address has been updated.

--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -42,6 +42,7 @@ resource "metal_public_ip" "my_ip" {
 - `type` (String) Determines the type of the public ip address. 
 	If you want the IP to outlive the cluster lifecycle, mark it as static. Otherwise it will be deleted along with the cluster. 
 	Another use case would be if you want to have a stable egress address on the internet gateway for your cluster.
+	Must be either 'static' or 'ephemeral'. Static IPs cannot be made ephemeral.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/metal-stack-cloud/terraform-provider-metal
 
-go 1.21
+go 1.22
 
-toolchain go1.21.0
+toolchain go1.22.0
 
 require (
 	connectrpc.com/connect v1.15.0

--- a/internal/cluster/cluster_acc_test.go
+++ b/internal/cluster/cluster_acc_test.go
@@ -1,7 +1,10 @@
 package cluster_test
 
 import (
+	"strings"
 	"testing"
+
+	"math/rand/v2"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -22,7 +25,7 @@ func TestAccClusterResourceAndDataSource(t *testing.T) {
 			{
 				Config: testAccExampleClusterSeed,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("metal_cluster.acctest", "name", "tf-acctest"),
+					resource.TestCheckResourceAttr("metal_cluster.acctest", "name", "tf-c-"+runId),
 				),
 			},
 			{
@@ -34,16 +37,26 @@ func TestAccClusterResourceAndDataSource(t *testing.T) {
 			{
 				Config: testAccExampleClusterSeedWithAllFields,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("metal_cluster.acctest", "name", "tf-acctest"),
+					resource.TestCheckResourceAttr("metal_cluster.acctest", "name", "tf-c-"+runId),
 				),
 			},
 		},
 	})
 }
 
-const testAccExampleClusterSeed = `
+var (
+	runId = func(n int) string {
+		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+		var str strings.Builder
+		for range n {
+			str.WriteByte(letters[rand.N(len(letters))])
+		}
+		return str.String()
+	}(5)
+
+	testAccExampleClusterSeed = `
 resource "metal_cluster" "acctest" {
-	name = "tf-acctest"
+	name = "tf-c-` + runId + `"
 	kubernetes = "1.27.9"
 	workers = [
 		{
@@ -63,15 +76,15 @@ resource "metal_cluster" "acctest" {
 }
 `
 
-const testAccExampleDataSource = `
+	testAccExampleDataSource = `
 data "metal_cluster" "acctest-data" {
-	name = "tf-acctest"
+	name = "tf-c-` + runId + `"
 }
 `
 
-const testAccExampleClusterSeedWithAllFields = `
+	testAccExampleClusterSeedWithAllFields = `
 resource "metal_cluster" "acctest" {
-	name = "tf-acctest"
+	name = "tf-c-` + runId + `"
 	kubernetes = "1.27.9"
 	workers = [
 		{
@@ -92,3 +105,4 @@ resource "metal_cluster" "acctest" {
 	// }
 }
 `
+)

--- a/internal/cluster/cluster_acc_test.go
+++ b/internal/cluster/cluster_acc_test.go
@@ -46,7 +46,7 @@ func TestAccClusterResourceAndDataSource(t *testing.T) {
 
 var (
 	runId = func(n int) string {
-		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+		const letters = "abcdefghijklmnopqrstuvwxyz1234567890"
 		var str strings.Builder
 		for range n {
 			str.WriteByte(letters[rand.N(len(letters))])

--- a/internal/public_ip/schema.go
+++ b/internal/public_ip/schema.go
@@ -96,6 +96,7 @@ func publicIpResourceAttributes() map[string]resourceschema.Attribute {
 			Description: "The project this address is part of. Cannot be moved.",
 		},
 		"type": resourceschema.StringAttribute{
+			Optional: true,
 			Computed: true,
 			Default:  stringdefault.StaticString("ephemeral"),
 			Description: `Determines the type of the public ip address. 

--- a/internal/public_ip/schema.go
+++ b/internal/public_ip/schema.go
@@ -102,6 +102,7 @@ func publicIpResourceAttributes() map[string]resourceschema.Attribute {
 			Description: `Determines the type of the public ip address. 
 	If you want the IP to outlive the cluster lifecycle, mark it as static. Otherwise it will be deleted along with the cluster. 
 	Another use case would be if you want to have a stable egress address on the internet gateway for your cluster.
+	Must be either 'static' or 'ephemeral'. Static IPs cannot be made ephemeral.
 			`,
 			Validators: []validator.String{
 				stringvalidator.OneOf("ephemeral", "static"),


### PR DESCRIPTION
Due to the missing `Optional: true` changing the IP type was not possible as it was only computed.