### PR TITLE
test: pre-check goreleaser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: 'go.mod'
+          cache: true
       - name: Check GoReleaser
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,17 @@ jobs:
           TF_ACC: "1"
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 10
+
+  check-release:
+    name: Goreleaser Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check GoReleaser
+        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
+        with:
+          args: check
+        env:
+          # GitHub sets the GITHUB_TOKEN secret automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      

--- a/.github/workflows/testacc.yaml
+++ b/.github/workflows/testacc.yaml
@@ -31,6 +31,13 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
           version: latest
+      - name: Check GoReleaser
+        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
+        with:
+          args: check
+        env:
+          # GitHub sets the GITHUB_TOKEN secret automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: make testacc
         env:
           METAL_STACK_CLOUD_API_TOKEN: ${{ secrets.METAL_STACK_CLOUD_API_TOKEN }}

--- a/.github/workflows/testacc.yaml
+++ b/.github/workflows/testacc.yaml
@@ -31,13 +31,6 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
           version: latest
-      - name: Check GoReleaser
-        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
-        with:
-          args: check
-        env:
-          # GitHub sets the GITHUB_TOKEN secret automatically.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: make testacc
         env:
           METAL_STACK_CLOUD_API_TOKEN: ${{ secrets.METAL_STACK_CLOUD_API_TOKEN }}


### PR DESCRIPTION
Due to the updated goreleaser we had some hickups while releasing. This should run a pre-check as linter