### PR TITLE
fix: goreleaser format deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:


### PR DESCRIPTION
This broke our CI pipeline like in #192 due to the deprecation.
See https://goreleaser.com/deprecations/#active-deprecation-notices for more details