### PR TITLE
fix(cluster): reconnect on http errors #219

### DIFF
--- a/internal/cluster/helpers.go
+++ b/internal/cluster/helpers.go
@@ -249,6 +249,12 @@ func clusterOperationWaitStatus(ctx context.Context, c *ClusterResource, statusR
 			// reconnect if EOF error
 			continue
 		}
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) && (connectErr.Code() == connect.CodeDeadlineExceeded || connectErr.Code() == connect.CodeUnavailable) {
+			// reconnect on http connection issues
+			continue
+		}
+
 		if err != nil {
 			tflog.Debug(ctx, fmt.Sprintf("unknown stream connection error encountered with cluster status %v", clusterStatusStateSucceeded), map[string]any{
 				"error": err.Error(),


### PR DESCRIPTION
When the creation of a cluster takes longer than expected, the GRPC stream might hit the maximum duration leading to an error. In case one of these additional errors occur, a reconnect will be attempted.

See https://github.com/metal-stack-cloud/terraform-provider-metal-examples/actions/runs/15652364040/job/44098743824

Fixes #219 