### PR TITLE
Bump github.com/metal-stack-cloud/api from 0.16.1 to 0.16.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
-	github.com/metal-stack-cloud/api v0.16.1
+	github.com/metal-stack-cloud/api v0.16.3
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/metal-stack-cloud/api v0.16.1 h1:25O1Ox+PerTpLDabFJyvlL1cqLRZy47UdVIzhN+R8uY=
-github.com/metal-stack-cloud/api v0.16.1/go.mod h1:jntKlK1FD+YYp1cBS/4bhQKg4vjchdnUY8i/jyX+O2Y=
+github.com/metal-stack-cloud/api v0.16.3 h1:gUXEQ6Z+WdknglOOhhFBfdinbeItzyLAuUbX9ZmN8oU=
+github.com/metal-stack-cloud/api v0.16.3/go.mod h1:fct2KsojPKyGgB7bZun42Teb80Pb4LvnMmAOfcco0N0=
 github.com/minio/minlz v1.0.1 h1:OUZUzXcib8diiX+JYxyRLIdomyZYzHct6EShOKtQY2A=
 github.com/minio/minlz v1.0.1/go.mod h1:qT0aEB35q79LLornSzeDH75LBf3aH1MV+jB5w9Wasec=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -139,13 +139,17 @@ func (p *MetalstackCloudProvider) Configure(ctx context.Context, req provider.Co
 		)
 	}
 
-	dialConfig := client.DialConfig{
+	debugLevel := slog.LevelInfo
+	if shared.Debug {
+		debugLevel = slog.LevelDebug
+	}
+
+	apiClient := client.New(&client.DialConfig{
 		BaseURL:   apiUrl,
 		Token:     apiToken,
 		UserAgent: "terraform-provider-metal/" + p.version,
-		Debug:     shared.Debug,
-	}
-	apiClient := client.New(dialConfig)
+		Log:       slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: debugLevel})),
+	})
 
 	err = assumeDefaultsFromApiClient(ctx, apiClient)
 	if err != nil {


### PR DESCRIPTION
Bump `github.com/metal-stack-cloud/api` with slight code refactoring.
Replaces #277 